### PR TITLE
allow use of public subnets

### DIFF
--- a/vsensors.tf
+++ b/vsensors.tf
@@ -22,18 +22,14 @@ locals {
 #
 
 resource "aws_launch_template" "vsensor" {
-  name          = "${local.deployment_id}-vsensor-${local.instance_version}"
-  description   = "vSensor Launch Template"
-  image_id      = data.aws_ami.ubuntu.id
-  instance_type = var.instance_type
+  name                   = "${local.deployment_id}-vsensor-${local.instance_version}"
+  description            = "vSensor Launch Template"
+  image_id               = data.aws_ami.ubuntu.id
+  instance_type          = var.instance_type
+  vpc_security_group_ids = [aws_security_group.vsensors_asg_sg.id]
 
   iam_instance_profile {
     name = aws_iam_instance_profile.vsensor.name
-  }
-
-  network_interfaces {
-    associate_public_ip_address = false
-    security_groups             = [aws_security_group.vsensors_asg_sg.id]
   }
 
   key_name = var.ssh_keyname


### PR DESCRIPTION
The `associate_public_ip_address = false` network interface setting overrides the subnet setting. If you attempt to use public subnets for the vSensor, your instances will not get a public IP associated with them and they will be unable to reach the internet to do the installs. Removing this section allows the subnet defaults to apply and works with both private and public subnets.