### PR TITLE
Wrong error message for instance_type variable

### DIFF
--- a/s3_pcaps.tf
+++ b/s3_pcaps.tf
@@ -39,6 +39,8 @@ resource "aws_s3_bucket_lifecycle_configuration" "vsensor_pcaps_s3" {
   rule {
     id = "delete-after-${var.lifecycle_pcaps_s3_bucket}-days"
 
+    filter {}
+
     expiration {
       days = var.lifecycle_pcaps_s3_bucket
     }

--- a/variables.tf
+++ b/variables.tf
@@ -59,7 +59,7 @@ variable "instance_type" {
 
   validation {
     condition     = contains(["t3.medium", "m5.large", "m6i.large", "m7i.large", "m5.xlarge", "m6i.xlarge", "m7i.xlarge", "m5.2xlarge", "m6i.2xlarge", "m6i.2xlarge", "m5.4xlarge", "m6i.4xlarge", "m7i.4xlarge"], var.instance_type)
-    error_message = "The instance_type can be one of t3.medium, m5.large, m5.2xlarge, m5.4xlarge."
+    error_message = "The instance_type can be one of t3.medium, m5.large, m6i.large, m7i.large, m5.xlarge, m6i.xlarge, m7i.xlarge, m5.2xlarge, m6i.2xlarge, m6i.2xlarge, m5.4xlarge, m6i.4xlarge, or m7i.4xlarge."
   }
 }
 


### PR DESCRIPTION
The error message on the instance_type variable was not including all of the supported instance types.  I was trying to use an unsupported instance and was questioning why only the m5 instances were supported.  Forked the code to fix it and do a PR and realized its just the error message that is wrong.  Hope this helps!