### PR TITLE
vSensor volume size

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -63,6 +63,17 @@ variable "instance_type" {
   }
 }
 
+variable "instance_volume_size" {
+  type        = number
+  description = "The size of the volume in GB for the vSensor instances. The default is 20 GB, but it can be increased if you expect high traffic and more data to be processed by the vSensor."
+  default     = 20
+
+  validation {
+    condition     = floor(var.instance_volume_size) == var.instance_volume_size && var.instance_volume_size >= 20 && var.instance_volume_size <= 1000
+    error_message = "The instance_volume_size must be a whole number between 20 and 1000 GB."
+  }
+}
+
 variable "ssh_keyname" {
   type        = string
   description = "(Optional) Name of the ssh key pair stored in AWS. This key will be added to the vSensor ssh configuration."

--- a/vsensors.tf
+++ b/vsensors.tf
@@ -66,8 +66,8 @@ resource "aws_launch_template" "vsensor" {
     ebs {
       delete_on_termination = true
       encrypted             = true
-      volume_size           = 20
-      volume_type           = "gp2"
+      volume_size           = var.instance_volume_size
+      volume_type           = "gp3"
 
     }
   }


### PR DESCRIPTION
The volume size of the vSensor should be a variable instead of being hard coded in the module as 20GB.  Additionally, I changed volume type from GP2 to GP3 for better performance.  Ideally, these volumes should also be able to be encrypted with custom KMS as well if an optional key ARN is passed. 